### PR TITLE
Improve update_styrdokument.sh

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-ruby
-https://github.com/gulopine/heroku-buildpack-tex
+https://github.com/dkd/heroku-buildpack-tex

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec unicorn -p $PORT -c ./unicorn.rb
+web: ./update_styrdokument.sh && bundle exec unicorn -p $PORT -c ./unicorn.rb

--- a/styrdokument.rb
+++ b/styrdokument.rb
@@ -22,4 +22,3 @@ class Styrdokument < Sinatra::Base
     send_file "public/#{asset}"
   end
 end
-

--- a/update_styrdokument.sh
+++ b/update_styrdokument.sh
@@ -7,10 +7,9 @@ fi
 
 (
   cd styrdokument
-  git pull
-  make
-  make textile
-  make toc
+  git fetch origin master
+  git reset --hard origin/master
+  make clean pdf textile toc
   cp *.pdf ../public
   cp *.textile ../views
 

--- a/update_styrdokument.sh
+++ b/update_styrdokument.sh
@@ -5,6 +5,8 @@ if [ ! -e "styrdokument" ]; then
   git clone git://github.com/datasektionen/styrdokument.git
 fi
 
+tlmgr install titlesec lastpage
+
 (
   cd styrdokument
   git fetch origin master
@@ -13,7 +15,7 @@ fi
   cp *.pdf ../public
   cp *.textile ../views
 
-  for file in `ls +(!(*toc*)textile)|sed -e 's/.textile//'`; do 
+  for file in `ls +(!(*toc*)textile)|sed -e 's/.textile//'`; do
     document="../views/$file.textile";
     echo '<div class="pull-right toc">' > $document;
     echo '' >> $document;


### PR DESCRIPTION
- Update styrdokument repository unconditionally, using `git fetch` and `git reset --hard`
- Group the `make` commands together, and always start from a pristine state, using `make clean`
- Make sure to run `update_styrdokument.sh` script before starting web daemon, to ensure everything is actually in place when the page comes up
